### PR TITLE
Add missing error message for 'invalid' datetimes

### DIFF
--- a/epochdatetimefield/fields.py
+++ b/epochdatetimefield/fields.py
@@ -5,7 +5,9 @@ from django.db import models
 from django import forms
 from django.core import exceptions
 from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
+
 
 class EpochDateTimeField(models.Field):
     """
@@ -18,6 +20,9 @@ class EpochDateTimeField(models.Field):
     """
 
     __metaclass__ = models.SubfieldBase
+    default_error_messages = {
+        'invalid': _("'%(value)s' value was not parsable as a datetime."),
+    }
 
     def get_internal_type(self):
         """

--- a/epochdatetimefield/tests/test_models.py
+++ b/epochdatetimefield/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.utils import timezone
 from django.test import TestCase
+from django.core import exceptions
 
 from .models import (
     TestModel, TestModelWithNullableField,
@@ -43,6 +44,11 @@ class EpochDateTimeFieldTest(TestCase):
             token.test_field,
             self.date
         )
+
+    def test_unparsable_value(self):
+        field, _, _, _ = TestModel._meta.get_field_by_name('test_field')
+        with self.assertRaises(exceptions.ValidationError):
+            field.to_python('12345/22/22')
 
 
 class NullableFieldTest(TestCase):


### PR DESCRIPTION
### What is the problem / feature ?

`EpochDateTimeField` expected to have an `invalid` key in it's error messages.
### How did it get fixed / implemented ?

Added an `invalid` error message to the `default_error_messages` dict on the class.
### How can someone test / see it ?

Load an unparsable datetime.

_Here is a cute baby animal picture for your troubles..._

![ig0hxdg](https://cloud.githubusercontent.com/assets/824194/2920636/7493aa70-d6e9-11e3-935f-ed8ec43c08c0.jpg)
